### PR TITLE
fixes to support newer gfortran compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@
 set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/config)
 
 INCLUDE(CMakeForceCompiler) #Necessary to change between MPI/parallel/profiler compilers, without having to do a make clean
-cmake_minimum_required (VERSION 2.8.1)
+cmake_minimum_required (VERSION 3.0.0)
 set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 
@@ -44,6 +44,7 @@ project (uclales Fortran)
 set (MPI TRUE CACHE BOOL "Choose to enable MPI or not.")
 if(MPI)
  MESSAGE(STATUS "MPI is Enabled.")
+ find_package(MPI REQUIRED)
  FILE(GLOB mpifile "${CMAKE_CURRENT_SOURCE_DIR}/src/mpi/mpi_interface.f90")
 else()
   MESSAGE(STATUS "MPI is Disabled.")
@@ -69,19 +70,6 @@ else()
 endif()
 
 
-set(INCLUDE_DIRS ${NETCDF_INCLUDE_DIR})
+set(INCLUDE_DIRS ${NETCDF_INCLUDE_DIR} ${MPI_Fortran_INCLUDE_DIRS})
 
 add_subdirectory(src)
-
-
-#####################
-# DOCUMENTATION
-#####################
-add_custom_target(todo ALL)
-ADD_CUSTOM_COMMAND(TARGET todo POST_BUILD
-                  COMMAND echo "UCLALES TODO LIST" > TODO
-                  COMMAND date  >> TODO
-                  COMMAND grep -Rin \\todo  src | sed 's/!.*TODO//I' >>  TODO
-                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                  )
-

--- a/src/forc.f90
+++ b/src/forc.f90
@@ -52,7 +52,8 @@ contains
     use grid, only: nxp, nyp, nzp, zm, zt, dzi_t, dzi_m, dn0, iradtyp, isfctyp, liquid  &
          , a_rflx, a_sflx, albedo, a_tt, a_tp, a_rt, a_rp, a_pexnr, a_scr1 &
          , vapor, a_rpp,a_ricep,a_nicep,a_rgrp, CCN, pi0, pi1, level, a_ut, a_up, a_vt, a_vp,a_theta,&
-          a_lflxu, a_lflxd, a_sflxu, a_sflxd,sflxu_toa,sflxd_toa,lflxu_toa,lflxd_toa,a_lflxu_ca, a_lflxd_ca, a_sflxu_ca, a_sflxd_ca, lflxd_toa_ca, lflxu_toa_ca, sflxd_toa_ca, sflxu_toa_ca, a_wt, xt
+          a_lflxu, a_lflxd, a_sflxu, a_sflxd,sflxu_toa,sflxd_toa,lflxu_toa,lflxd_toa,a_lflxu_ca, &
+          a_lflxd_ca, a_sflxu_ca, a_sflxd_ca, lflxd_toa_ca, lflxu_toa_ca, sflxd_toa_ca, sflxu_toa_ca, a_wt, xt
 
     use mpi_interface, only : myid, appl_abort
     use util, only : get_avg

--- a/src/grid.f90
+++ b/src/grid.f90
@@ -78,7 +78,8 @@ module grid
   ! 2D Arrays (surface fluxes)
   !
   real, dimension (:,:), allocatable :: albedo, a_ustar, a_tstar, a_rstar,    &
-       uw_sfc, vw_sfc, ww_sfc, wt_sfc, wq_sfc, trac_sfc, sflxu_toa,sflxd_toa,lflxu_toa,lflxd_toa, sflxu_toa_ca,sflxd_toa_ca,lflxu_toa_ca,lflxd_toa_ca, &
+       uw_sfc, vw_sfc, ww_sfc, wt_sfc, wq_sfc, trac_sfc, sflxu_toa,sflxd_toa, &
+       lflxu_toa,lflxd_toa, sflxu_toa_ca,sflxd_toa_ca,lflxu_toa_ca,lflxd_toa_ca, &
        cnd_acc, &  ! accumulated condensation  [kg/m2] (diagnostic for 2D output)
        cev_acc, &  ! accumulated evaporation of cloud water [kg/m2] (diagnostic for 2D output)
        rev_acc, &  ! accumulated evaporation of rainwater   [kg/m2] (diagnostic for 2D output)

--- a/src/ice_sb.F90
+++ b/src/ice_sb.F90
@@ -2589,6 +2589,19 @@ CONTAINS
 
   END FUNCTION double_global_maxval
 
+  FUNCTION real_global_maxval(feld)
+    use mpi_interface,  only : myid, real_scalar_par_max
+    IMPLICIT NONE
+
+    real, DIMENSION(:,:,:),INTENT(in):: feld
+    real :: loc_max, real_global_maxval
+
+    loc_max = MAXVAL(feld)
+
+    call real_scalar_par_max(loc_max,real_global_maxval)
+
+  END FUNCTION real_global_maxval
+
   FUNCTION double_global_sumval(feld)
     use mpi_interface,  only : myid, double_scalar_par_sum
     IMPLICIT NONE

--- a/src/icemcrp.f90
+++ b/src/icemcrp.f90
@@ -42,7 +42,7 @@ module mcrp
        prc_c, prc_r, prc_i, prc_s, prc_g, prc_h, & 
        lwaterbudget, prc_acc, rev_acc, a_rct, cnd_acc, cev_acc, a_cld,prc_lev, lmptend
 
-  USE parallele_umgebung, ONLY: isIO,double_global_maxval,global_maxval,global_minval,global_maxval_stdout,global_sumval_stdout
+  USE parallele_umgebung, ONLY: isIO,real_global_maxval,global_maxval,global_minval,global_maxval_stdout,global_sumval_stdout
   USE modcross, ONLY: calcintpath
 
   use thrm, only : thermo, fll_tkrs, esl, esi
@@ -228,14 +228,14 @@ contains
              else
                 rct_acc = rct_acc - sum(tmp)*dt
              end if
-             call double_scalar_par_sum(rct_acc,hlp7)
+             call real_scalar_par_sum(rct_acc,hlp7)
              call calcintpath(a_rpt,tmp)
              if (istep.le.1) then
                 rpt_acc = sum(tmp)*dt
              else
                 rpt_acc = rpt_acc + sum(tmp)*dt
              end if
-             call double_scalar_par_sum(rpt_acc,hlp8)
+             call real_scalar_par_sum(rpt_acc,hlp8)
              
              hsum = sum(cnd_acc) ; call double_scalar_par_sum(hsum,hlp1)
              hsum = sum(cev_acc) ; call double_scalar_par_sum(hsum,hlp2)
@@ -433,16 +433,19 @@ contains
              case(iriming_ice_cloud)
                 call resetvar(cldw,rc)
                 call resetvar(ice,rice,nice)
-                call ice_cloud_riming(n1,cldw,ice,rc,rice,nice,rgrp,tl,temp,d_coll_c,r_crit_c,d_crit_c,r_crit_ic,d_crit_ic,d_conv_ig,e_ic)
+                call ice_cloud_riming(n1,cldw,ice,rc,rice,nice,rgrp,tl,temp,d_coll_c,r_crit_c,d_crit_c,&
+                                      r_crit_ic,d_crit_ic,d_conv_ig,e_ic)
              case(iriming_snow_cloud)
                 call resetvar(snow,rsnow)
                 call resetvar(cldw,rc)
-                call ice_cloud_riming(n1,cldw,snow,rc,rsnow,nsnow,rgrp,tl,temp,d_coll_c,r_crit_c,d_crit_c,r_crit_sc,d_crit_sc,d_conv_sg,e_sc)
+                call ice_cloud_riming(n1,cldw,snow,rc,rsnow,nsnow,rgrp,tl,temp,d_coll_c,r_crit_c,d_crit_c,&
+                                      r_crit_sc,d_crit_sc,d_conv_sg,e_sc)
              case(iriming_grp_cloud)
                 call resetvar(graupel,rgrp)
                 call resetvar(cldw,rc)
                 r1 = 0.
-                call ice_cloud_riming(n1,cldw,graupel,rc,rgrp,ngrp,r1,tl,temp,d_coll_c,r_crit_c,d_crit_c,r_crit_gc,d_crit_gc,d_conv_sg,e_gc)
+                call ice_cloud_riming(n1,cldw,graupel,rc,rgrp,ngrp,r1,tl,temp,d_coll_c,r_crit_c,d_crit_c,&
+                                      r_crit_gc,d_crit_gc,d_conv_sg,e_gc)
                 rgrp = rgrp + r1
              case(iriming_ice_rain)
                 call resetvar(ice,rice,nice)
@@ -2983,16 +2986,16 @@ contains
     END IF
 
     IF (debug_maxval) THEN
-       wmax  = double_global_maxval(w(kts:kte,jts:jte,its:ite))
-       qvmax = double_global_maxval(qv(kts:kte,jts:jte,its:ite))
-       qcmax = double_global_maxval(qc(kts:kte,jts:jte,its:ite))
-       qrmax = double_global_maxval(qr(kts:kte,jts:jte,its:ite))
-       qimax = double_global_maxval(qi(kts:kte,jts:jte,its:ite))
-       qsmax = double_global_maxval(qs(kts:kte,jts:jte,its:ite))
-       qgmax = double_global_maxval(qg(kts:kte,jts:jte,its:ite))
-       qhmax = double_global_maxval(qh(kts:kte,jts:jte,its:ite))
-       nimax = double_global_maxval(qni(kts:kte,jts:jte,its:ite))
-       tmax  = double_global_maxval(tk(kts:kte,jts:jte,its:ite))
+       wmax  = real_global_maxval(w(kts:kte,jts:jte,its:ite))
+       qvmax = real_global_maxval(qv(kts:kte,jts:jte,its:ite))
+       qcmax = real_global_maxval(qc(kts:kte,jts:jte,its:ite))
+       qrmax = real_global_maxval(qr(kts:kte,jts:jte,its:ite))
+       qimax = real_global_maxval(qi(kts:kte,jts:jte,its:ite))
+       qsmax = real_global_maxval(qs(kts:kte,jts:jte,its:ite))
+       qgmax = real_global_maxval(qg(kts:kte,jts:jte,its:ite))
+       qhmax = real_global_maxval(qh(kts:kte,jts:jte,its:ite))
+       nimax = real_global_maxval(qni(kts:kte,jts:jte,its:ite))
+       tmax  = real_global_maxval(tk(kts:kte,jts:jte,its:ite))
        IF (isIO()) THEN
           WRITE (*,*) "mcrph_sb: output before microphysics"
           WRITE(*,'(10x,a)') 'Maximum Values:'
@@ -3019,7 +3022,7 @@ contains
           DO kk = kts, kte
              ! supersaturation w.r.t. ice
              hlp           = p00 * ((pi0(kk)+pi1(kk)+exner(kk,jj,ii))/cp)**cpr
-             ssi(kk,jj,ii) = qv(kk,jj,ii)/rsif(hlp,tk(kk,jj,ii)) - 1.0
+             ssi(kk,jj,ii) = qv(kk,jj,ii)/rsif(real(hlp),tk(kk,jj,ii)) - 1.0
 
 !             ssi(kk,jj,ii) =  R_d & 
 !                  & * dn0(kk) * qv(kk,jj,ii) &
@@ -3570,16 +3573,16 @@ contains
     END DO
 
     IF (debug_maxval) THEN
-       wmax  = double_global_maxval(w)
-       qvmax = double_global_maxval(qv)
-       qcmax = double_global_maxval(qc)
-       qrmax = double_global_maxval(qr)
-       qimax = double_global_maxval(qi)
-       qsmax = double_global_maxval(qs)
-       qgmax = double_global_maxval(qg)
-       qhmax = double_global_maxval(qh)
-       nimax = double_global_maxval(qni)
-       tmax  = double_global_maxval(tk)
+       wmax  = real_global_maxval(w)
+       qvmax = real_global_maxval(qv)
+       qcmax = real_global_maxval(qc)
+       qrmax = real_global_maxval(qr)
+       qimax = real_global_maxval(qi)
+       qsmax = real_global_maxval(qs)
+       qgmax = real_global_maxval(qg)
+       qhmax = real_global_maxval(qh)
+       nimax = real_global_maxval(qni)
+       tmax  = real_global_maxval(tk)
        IF (isIO()) THEN
           WRITE (*,*) "mcrph_sb: output after microphysics and sedimentation"
           WRITE(*,'(10x,a)') 'Maximum Values:'

--- a/src/init.f90
+++ b/src/init.f90
@@ -60,7 +60,9 @@ contains
     use mcrp, only : initmcrp
     use modcross, only : initcross, triggercross
     use grid, only : nzp, dn0, u0, v0, zm, zt, isfctyp
-    use modparticles, only: init_particles, lpartic, lpartdump, lpartstat, initparticledump, initparticlestat, write_particle_hist, particlestat
+    use modparticles, only: init_particles, lpartic, lpartdump, lpartstat, &
+                            initparticledump, initparticlestat, &
+                            write_particle_hist, particlestat
 
     implicit none
 

--- a/src/modcross.f90
+++ b/src/modcross.f90
@@ -428,7 +428,8 @@ contains
           dimname(2)            = yname
           dimlongname(2)        = ylongname
           do n = 1, nkcross
-            call addvar_nc(nccrossxyid, trim(name)//trim(hname(n)), 'xy crosssection of '//trim(longname)//' at '//trim(hlname(n)), &
+            call addvar_nc(nccrossxyid, trim(name)//trim(hname(n)), 'xy crosssection of ' &
+                           //trim(longname)//' at '//trim(hlname(n)), &
             unit, dimname, dimlongname, dimunit, dimsize, dimvalues)
           end do
           crossname(ncross) = name
@@ -524,7 +525,8 @@ contains
              p(k,i,j) = p00 * (exner)**cpr
              tk=a_theta(k,i,j)*exner
              tstar = 1./(1./(tk-55.)-log(a_rp(k,i,j)/rslf(p(k,i,j),tk))/2840.)+55.
-             th_e(k,i,j) = tk*(p00/p(k,i,j))**(0.2854*(1.-0.28*a_rp(k,i,j)))*exp(a_rp(k,i,j)*(1.+0.81*a_rp(k,i,j))*(3376./tstar-2.54))
+             th_e(k,i,j) = tk*(p00/p(k,i,j))**(0.2854*(1.-0.28*a_rp(k,i,j)))* &
+                           exp(a_rp(k,i,j)*(1.+0.81*a_rp(k,i,j))*(3376./tstar-2.54))
           end do
        end do
       end do
@@ -855,7 +857,7 @@ contains
   subroutine calcavg(varin, mask, varout)
     use modnetcdf, only : fillvalue_double
     use grid, only : nzp, nxp, nyp
-    use mpi_interface, only : double_array_par_sum
+    use mpi_interface, only : real_array_par_sum
     real, intent(in), dimension(:,:,:) :: varin, mask
     real, intent(out), dimension(:)  :: varout
     real, dimension(SIZE(varout))  :: varoutsum, lvaroutsum, gvaroutsum
@@ -881,9 +883,9 @@ contains
 
     n=size(varout)
     lvaroutsum=varoutsum
-    call double_array_par_sum(lvaroutsum,gvaroutsum,n)
+    call real_array_par_sum(lvaroutsum,gvaroutsum,n)
     lncl=ncl
-    call double_array_par_sum(lncl,gncl,n)
+    call real_array_par_sum(lncl,gncl,n)
 
     do k=1,nzp
        if (gncl(k) == 0. ) then
@@ -897,7 +899,7 @@ contains
   subroutine calcavgcld(varin, mask, varout)
     use modnetcdf, only : fillvalue_double
     use grid, only : nzp, nxp, nyp
-    use mpi_interface, only : double_array_par_sum
+    use mpi_interface, only : real_array_par_sum
     real, intent(in), dimension(:,:,:) :: varin, mask
     real, intent(out), dimension(:)  :: varout
     real, dimension(SIZE(varout))  :: varoutsum, lvaroutsum, gvaroutsum
@@ -922,9 +924,9 @@ contains
 
     n=size(varout)
     lvaroutsum=varoutsum
-    call double_array_par_sum(lvaroutsum,gvaroutsum,n)
+    call real_array_par_sum(lvaroutsum,gvaroutsum,n)
     lncl=ncl
-    call double_array_par_sum(lncl,gncl,n)
+    call real_array_par_sum(lncl,gncl,n)
 
     do k=1,nzp
        if (gncl(k) == 0. ) then

--- a/src/modnudge.f90
+++ b/src/modnudge.f90
@@ -66,7 +66,8 @@ contains
     real :: highheight,highqtnudge,highthlnudge,highunudge,highvnudge,highwnudge,hightnudge
     real :: lowheight,lowqtnudge,lowthlnudge,lowunudge,lowvnudge,lowwnudge,lowtnudge
     real :: fac
-    allocate(tnudge(nzp,ntnudge),unudge(nzp,ntnudge),vnudge(nzp,ntnudge),wnudge(nzp,ntnudge),thlnudge(nzp,ntnudge),qtnudge(nzp,ntnudge))
+    allocate(tnudge(nzp,ntnudge),unudge(nzp,ntnudge),vnudge(nzp,ntnudge),wnudge(nzp,ntnudge))
+    allocate(thlnudge(nzp,ntnudge),qtnudge(nzp,ntnudge))
     allocate(timenudge(0:ntnudge), height(nzp))
     tnudge = 0
     unudge=0

--- a/src/mpi/mpi_interface.f90
+++ b/src/mpi/mpi_interface.f90
@@ -611,16 +611,13 @@ contains
   !---------------------------------------------------------------------------
   ! get maximum across processors
   !
-  subroutine real_scalar_par_max(rxl,xxg)
+  subroutine real_scalar_par_max(rxl,rxg)
 
     real, intent(in) :: rxl
-    real(kind=8), intent(out) :: xxg
-    real(kind=8) :: xxl
+    real, intent(out) :: rxg
     integer:: mpiop,ierror
 
-    xxl = rxl
-
-    call mpi_allreduce(xxl,xxg,1,MPI_DOUBLE_PRECISION, MPI_MAX, &
+    call mpi_allreduce(rxl,rxg,1,MPI_REAL, MPI_MAX, &
          MPI_COMM_WORLD, ierror)
 
   end subroutine real_scalar_par_max
@@ -636,6 +633,17 @@ contains
          MPI_COMM_WORLD, ierror)
 
   end subroutine double_scalar_par_max
+
+  subroutine real_scalar_par_min(rxl,rxg)
+
+    real, intent(out) :: rxg
+    real, intent(in) :: rxl
+    integer:: mpiop,ierror
+
+    call mpi_allreduce(rxl,rxg,1,MPI_REAL, MPI_MIN, &
+         MPI_COMM_WORLD, ierror)
+
+  end subroutine real_scalar_par_min
 
   subroutine double_scalar_par_min(xxl,xxg)
 
@@ -673,6 +681,17 @@ contains
          MPI_COMM_WORLD, ierror)
 
   end subroutine double_array_par_sum
+
+  subroutine real_array_par_sum(xxl,xxg,n)
+    integer, intent(in)::n
+    real, intent(out) :: xxg(n)
+    real, intent(in) :: xxl(n)
+    integer:: mpiop,ierror
+
+    call mpi_allreduce(xxl,xxg,n,MPI_REAL, MPI_SUM, &
+         MPI_COMM_WORLD, ierror)
+  end subroutine real_array_par_sum
+
   subroutine broadcast(val, procsend)
    integer, intent(in) :: procsend
    real(kind=8), intent(inout) :: val

--- a/src/ncio.f90
+++ b/src/ncio.f90
@@ -628,7 +628,7 @@ contains
        if (itype==2) ncinfo = 'tttt'
     case('time')
        if (itype==0) ncinfo = 'Time'
-       if (itype==1) ncinfo = 'seconds since 2000-00-00 0000'
+       if (itype==1) ncinfo = 'seconds since 2000-01-01 0000'
        if (itype==2) ncinfo = 'time'
     case('zt')
        if (itype==0) ncinfo = 'Vertical displacement of cell centers'

--- a/src/particles.f90
+++ b/src/particles.f90
@@ -507,7 +507,8 @@ contains
     TYPE (particle_record), POINTER:: particle
 
     zbottom      = floor(particle%z + 0.5)
-    deltaz       = ((zm(floor(particle%z)) + (particle%z - floor(particle%z)) / dzi_t(floor(particle%z))) - zt(zbottom)) * dzi_m(zbottom)
+    deltaz       = ((zm(floor(particle%z)) + (particle%z - floor(particle%z)) / dzi_t(floor(particle%z))) &
+                    - zt(zbottom)) * dzi_m(zbottom)
     if(lfsloc) then
       fsl        = i3d(particle%x,particle%y,particle%z,fs_local)
     else
@@ -712,7 +713,8 @@ contains
       allocate(buffrecv(sum(recvcount)))
 
       ! Send all particles to all procs
-      call mpi_allgatherv(buffsend,nlocal*nrpartvar,mpi_double_precision,buffrecv,recvcount,displacements,mpi_double_precision,mpi_comm_world,ierror)
+      call mpi_allgatherv(buffsend,nlocal*nrpartvar,mpi_double_precision,buffrecv,recvcount,displacements,&
+                          mpi_double_precision,mpi_comm_world,ierror)
 
       ! Loop through particles, check if on this proc
       xsizelocal = nxg / nxprocs
@@ -1091,9 +1093,12 @@ contains
 
     particle%zprev = particle%z
 
-    particle%x     = particle%x + rka(nstep) * (particle%ures + particle%usgs) * dt + rkb(nstep) * (particle%ures_prev + particle%usgs_prev) * dt
-    particle%y     = particle%y + rka(nstep) * (particle%vres + particle%vsgs) * dt + rkb(nstep) * (particle%vres_prev + particle%vsgs_prev) * dt
-    particle%z     = particle%z + rka(nstep) * (particle%wres + particle%wsgs) * dt + rkb(nstep) * (particle%wres_prev + particle%wsgs_prev) * dt
+    particle%x     = particle%x + rka(nstep) * (particle%ures + particle%usgs) * dt &
+                     + rkb(nstep) * (particle%ures_prev + particle%usgs_prev) * dt
+    particle%y     = particle%y + rka(nstep) * (particle%vres + particle%vsgs) * dt &
+                     + rkb(nstep) * (particle%vres_prev + particle%vsgs_prev) * dt
+    particle%z     = particle%z + rka(nstep) * (particle%wres + particle%wsgs) * dt &
+                     + rkb(nstep) * (particle%wres_prev + particle%wsgs_prev) * dt
 
     particle%ures_prev = particle%ures
     particle%vres_prev = particle%vres
@@ -1122,7 +1127,9 @@ contains
   !--------------------------------------------------------------------------
   !
   subroutine partcomm
-    use mpi_interface, only : wrxid, wryid, ranktable, nxg, nyg, xcomm, ycomm, ierror, mpi_status_size, mpi_integer, mpi_double_precision, mpi_comm_world, nyprocs, nxprocs,myid
+    use mpi_interface, only : wrxid, wryid, ranktable, nxg, nyg, xcomm, ycomm, ierror, &
+                              mpi_status_size, mpi_integer, mpi_double_precision, &
+                              mpi_comm_world, nyprocs, nxprocs,myid
     use modnetcdf, only : fillvalue_double
     implicit none
 
@@ -1788,7 +1795,8 @@ contains
   !--------------------------------------------------------------------------
   !
   subroutine balanced_particledump(time)
-    use mpi_interface, only : mpi_comm_world, myid, mpi_integer, mpi_double_precision, ierror, nxprocs, nyprocs, mpi_status_size, wrxid, wryid, nxg, nyg, mpi_sum
+    use mpi_interface, only : mpi_comm_world, myid, mpi_integer, mpi_double_precision, ierror, &
+                              nxprocs, nyprocs, mpi_status_size, wrxid, wryid, nxg, nyg, mpi_sum
     use grid,          only : tname, deltax, deltay, dzi_t, zm, umean, vmean,level
     use modnetcdf,     only : writevar_nc, fillvalue_double !, nchandle_error
     use netcdf,        only : nf90_sync !,nf90_inq_dimid, nf90_inquire_dimension, nf90_noerr,
@@ -1943,7 +1951,8 @@ contains
           else
             end = sendbase(p+1)-1
           end if
-          call mpi_isend(sendbuff(start:end),tosend(p)*nvar,mpi_double_precision,p,(myid+1)*(p+nprocs),mpi_comm_world,req(isr),ierror)
+          call mpi_isend(sendbuff(start:end),tosend(p)*nvar,mpi_double_precision,p,(myid+1)*(p+nprocs),&
+                         mpi_comm_world,req(isr),ierror)
           isr = isr + 1
         end if
         if(toreceive(p) .gt. 0) then
@@ -1953,7 +1962,8 @@ contains
           else
             end = receivebase(p+1)-1
           end if
-          call mpi_irecv(recvbuff(start:end),toreceive(p)*nvar,mpi_double_precision,p,(p+1)*(myid+nprocs),mpi_comm_world,req(isr),ierror)
+          call mpi_irecv(recvbuff(start:end),toreceive(p)*nvar,mpi_double_precision,p,(p+1)*(myid+nprocs),&
+                         mpi_comm_world,req(isr),ierror)
           isr = isr + 1
         end if
       end do
@@ -2215,7 +2225,8 @@ contains
       allocate(buffrecv(sum(recvcount)))
 
       ! Send all unique-nd-cominations to all procs
-      call mpi_allgatherv(ndel_n,ndel,mpi_double_precision,buffrecv,recvcount,displacements,mpi_double_precision,mpi_comm_world,ierror)
+      call mpi_allgatherv(ndel_n,ndel,mpi_double_precision,buffrecv,recvcount,displacements,&
+                          mpi_double_precision,mpi_comm_world,ierror)
     end if
 
     i = 1
@@ -2496,7 +2507,8 @@ contains
   !--------------------------------------------------------------------------
   !
   subroutine init_particles(hot,hfilin)
-    use mpi_interface, only : wrxid, wryid, nxg, nyg, myid, nxprocs, nyprocs, appl_abort, ierror,mpi_double_precision,mpi_comm_world,mpi_min
+    use mpi_interface, only : wrxid, wryid, nxg, nyg, myid, nxprocs, nyprocs, &
+                              appl_abort, ierror,mpi_double_precision,mpi_comm_world,mpi_min
     use grid, only : zm, deltax, deltay, zt,dzi_t, nzp, nxp, nyp
     use grid, only : a_up, a_vp, a_wp
     use modnetcdf, only : fillvalue_double
@@ -2647,7 +2659,8 @@ contains
       do n = 1, np
       !if (mod(n,10000000)==0) print *,n
         read(ifinput,*) tstart, xstart, ystart, zstart
-        if(xstart < 0. .or. xstart > nxg*deltax .or. ystart < 0. .or. ystart > nyg*deltay .or. zstart < 0. .or. zstart > zm(nzp-1)) then
+        if(xstart < 0. .or. xstart > nxg*deltax .or. ystart < 0. .or. ystart > nyg*deltay &
+           .or. zstart < 0. .or. zstart > zm(nzp-1)) then
           if (myid == 0) then
             print *, '  ABORTING: particle initialized outsize domain'
             write (*,*) 'X,Y,Z = ', xstart,ystart,zstart
@@ -2939,11 +2952,14 @@ contains
     end if
     if(lpartdumpth) then
       call addvar_nc(ncpartid,'t','liquid water potential temperature','K',dimname,dimlongname,dimunit,dimsize,dimvalues,precis)
-      if(level > 0) call addvar_nc(ncpartid,'tv','virtual potential temperature','K',dimname,dimlongname,dimunit,dimsize,dimvalues,precis)
+      if(level > 0) call addvar_nc(ncpartid,'tv','virtual potential temperature','K',dimname,&
+                                   dimlongname,dimunit,dimsize,dimvalues,precis)
     end if
     if(lpartdumpmr) then
-      if(level > 0) call addvar_nc(ncpartid,'rt','total water mixing ratio','kg/kg',dimname,dimlongname,dimunit,dimsize,dimvalues,precis)
-      if(level > 1) call addvar_nc(ncpartid,'rl','liquid water mixing ratio','kg/kg',dimname,dimlongname,dimunit,dimsize,dimvalues,precis)
+      if(level > 0) call addvar_nc(ncpartid,'rt','total water mixing ratio','kg/kg',dimname,&
+                                   dimlongname,dimunit,dimsize,dimvalues,precis)
+      if(level > 1) call addvar_nc(ncpartid,'rl','liquid water mixing ratio','kg/kg',dimname,&
+                                   dimlongname,dimunit,dimsize,dimvalues,precis)
     end if
     if(lpartdrop.and.lpartmass) then
       call addvar_nc(ncpartid,'m','drop mass','kg',dimname,dimlongname,dimunit,dimsize,dimvalues,precis)
@@ -2988,12 +3004,18 @@ contains
     if(myid == 0) then
       call open_nc(trim(filprf)//'.particlestat.nc', ncpartstatid, ncpartstatrec, time, .false.)
       call addvar_nc(ncpartstatid,'np','Number of particles','-',dimname,dimlongname,dimunit,dimsize,dimvalues)
-      call addvar_nc(ncpartstatid,'u','resolved u-velocity of particle','m s-1',dimname,dimlongname,dimunit,dimsize,dimvalues)
-      call addvar_nc(ncpartstatid,'v','resolved v-velocity of particle','m s-1',dimname,dimlongname,dimunit,dimsize,dimvalues)
-      call addvar_nc(ncpartstatid,'w','resolved w-velocity of particle','m s-1',dimname,dimlongname,dimunit,dimsize,dimvalues)
-      call addvar_nc(ncpartstatid,'u_2','resolved u-velocity variance of particle','m2 s-1',dimname,dimlongname,dimunit,dimsize,dimvalues)
-      call addvar_nc(ncpartstatid,'v_2','resolved v-velocity variance of particle','m2 s-1',dimname,dimlongname,dimunit,dimsize,dimvalues)
-      call addvar_nc(ncpartstatid,'w_2','resolved w-velocity variance of particle','m2 s-1',dimname,dimlongname,dimunit,dimsize,dimvalues)
+      call addvar_nc(ncpartstatid,'u','resolved u-velocity of particle','m s-1',dimname,&
+                     dimlongname,dimunit,dimsize,dimvalues)
+      call addvar_nc(ncpartstatid,'v','resolved v-velocity of particle','m s-1',dimname,&
+                     dimlongname,dimunit,dimsize,dimvalues)
+      call addvar_nc(ncpartstatid,'w','resolved w-velocity of particle','m s-1',dimname,&
+                     dimlongname,dimunit,dimsize,dimvalues)
+      call addvar_nc(ncpartstatid,'u_2','resolved u-velocity variance of particle','m2 s-1',&
+                     dimname,dimlongname,dimunit,dimsize,dimvalues)
+      call addvar_nc(ncpartstatid,'v_2','resolved v-velocity variance of particle','m2 s-1',&
+                     dimname,dimlongname,dimunit,dimsize,dimvalues)
+      call addvar_nc(ncpartstatid,'w_2','resolved w-velocity variance of particle','m2 s-1',&
+                     dimname,dimlongname,dimunit,dimsize,dimvalues)
       call addvar_nc(ncpartstatid,'tke','resolved TKE of particle','m s-1',dimname,dimlongname,dimunit,dimsize,dimvalues)
       call addvar_nc(ncpartstatid,'t','liquid water potential temperature','K',dimname,dimlongname,dimunit,dimsize,dimvalues)
       if(level > 0) then

--- a/src/rad_driver.f90
+++ b/src/rad_driver.f90
@@ -40,7 +40,8 @@ module radiation
   contains
 
     subroutine d4stream(n1, n2, n3, alat, time, sknt, sfc_albedo, CCN, dn0, &
-         pi0, pi1, dzi_m, pip, th, rv, rc, tt, rflx, sflx,lflxu, lflxd,sflxu,sflxd, albedo, lflxu_toa, lflxd_toa, sflxu_toa, sflxd_toa, rr,ice,nice,grp)
+         pi0, pi1, dzi_m, pip, th, rv, rc, tt, rflx, sflx,lflxu, lflxd,sflxu,&
+         sflxd, albedo, lflxu_toa, lflxd_toa, sflxu_toa, sflxd_toa, rr,ice,nice,grp)
 
 
       integer, intent (in) :: n1, n2, n3

--- a/src/seq/seq_interface.f90
+++ b/src/seq/seq_interface.f90
@@ -333,4 +333,50 @@ contains
   end subroutine broadcast
 
 
+  !---------------------------------------------------------------------------
+  ! get maximum across processors (for real(4))
+  !
+  subroutine real_scalar_par_max(xxl,xxg)
+
+    real(kind=4), intent(out) :: xxg
+    real(kind=4), intent(in) :: xxl
+
+    xxg=xxl
+
+  end subroutine real_scalar_par_max
+  !
+  !---------------------------------------------------------------------------
+  ! get maximum across processors (for real(4))
+  !
+  subroutine real_scalar_par_min(xxl,xxg)
+
+    real(kind=4), intent(out) :: xxg
+    real(kind=4), intent(in) :: xxl
+
+    xxg=xxl
+
+  end subroutine real_scalar_par_min
+  !
+  !---------------------------------------------------------------------------
+  subroutine real_scalar_par_sum(xxl,xxg)
+
+    real(kind=4), intent(out) :: xxg
+    real(kind=4), intent(in) :: xxl
+
+    xxg=xxl
+
+  end subroutine real_scalar_par_sum
+  !
+  !---------------------------------------------------------------------------
+  subroutine real_array_par_sum(xxl,xxg,n)
+
+    integer, intent(in)::n
+    real(kind=4), intent(out) :: xxg(n)
+    real(kind=4), intent(in) :: xxl(n)
+
+    xxg=xxl
+
+  end subroutine real_array_par_sum
+
+
 end module mpi_interface

--- a/src/srfc.f90
+++ b/src/srfc.f90
@@ -731,7 +731,8 @@ contains
        do while (.true.)
          iter    = iter + 1
          Lold    = L
-         fx      = Rib - zt(2) / L * (log(zt(2) / z0hav) - psih(zt(2) / L) + psih(z0hav / L)) / (log(zt(2) / z0mav) - psim(zt(2) / L) + psim(z0mav / L)) ** 2.
+         fx      = Rib - zt(2) / L * (log(zt(2) / z0hav) - psih(zt(2) / L) + psih(z0hav / L)) &
+                   / (log(zt(2) / z0mav) - psim(zt(2) / L) + psim(z0mav / L)) ** 2.
          Lstart  = L - 0.001*L
          Lend    = L + 0.001*L
          fxdif   = (   (- zt(2) / Lstart * (log(zt(2) / z0hav) - psih(zt(2) / Lstart) + psih(z0hav / Lstart)) &
@@ -1076,10 +1077,14 @@ contains
         lambdash(ksoilmax,i,j) = lambdas(ksoilmax,i,j)
 
         !" Solve the diffusion equation for the heat transport
-        a_tsoil(1,i,j) = tsoilm(1,i,j) + rk3coef * ( lambdah(1,i,j) * (a_tsoil(2,i,j) - a_tsoil(1,i,j)) / dzsoilh(1) + a_G0(i,j) ) / dzsoil(1) / pCs(1,i,j)
+        a_tsoil(1,i,j) = tsoilm(1,i,j) + rk3coef * &
+                         ( lambdah(1,i,j) * (a_tsoil(2,i,j) - a_tsoil(1,i,j)) / dzsoilh(1) + a_G0(i,j) ) / dzsoil(1) / pCs(1,i,j)
 
         do k = 2, ksoilmax-1
-          a_tsoil(k,i,j) = tsoilm(k,i,j) + rk3coef / pCs(k,i,j) * ( lambdah(k,i,j) * (a_tsoil(k+1,i,j) - a_tsoil(k,i,j)) / dzsoilh(k) - lambdah(k-1,i,j) * (a_tsoil(k,i,j) - a_tsoil(k-1,i,j)) / dzsoilh(k-1) ) / dzsoil(k)
+          a_tsoil(k,i,j) = tsoilm(k,i,j) + rk3coef / pCs(k,i,j) * &
+                           ( lambdah(k,i,j) * (a_tsoil(k+1,i,j) - a_tsoil(k,i,j)) &
+                              / dzsoilh(k) - lambdah(k-1,i,j) * (a_tsoil(k,i,j) - a_tsoil(k-1,i,j)) / dzsoilh(k-1) ) &
+                           / dzsoil(k)
         end do
 
         a_tsoil(ksoilmax,i,j) = tsoilm(ksoilmax,i,j) &
@@ -1090,7 +1095,11 @@ contains
              ) / dzsoil(ksoilmax)
 
         !" Solve the diffusion equation for the moisture transport (closed bottom for now)
-        a_phiw(1,i,j) = phiwm(1,i,j) + rk3coef * ( lambdash(1,i,j) * (a_phiw(2,i,j) - a_phiw(1,i,j)) / dzsoilh(1) - gammash(1,i,j) - (phifrac(1,i,j) * LEveg + LEsoil) / (rowt*alvl)) / dzsoil(1)
+        a_phiw(1,i,j) = phiwm(1,i,j) &
+           + rk3coef * ( &
+               lambdash(1,i,j) * (a_phiw(2,i,j) - a_phiw(1,i,j)) &
+               / dzsoilh(1) - gammash(1,i,j) - (phifrac(1,i,j) * LEveg + LEsoil) / (rowt*alvl)&
+            ) / dzsoil(1)
 
         do k = 2, ksoilmax-1
           a_phiw(k,i,j) = phiwm(k,i,j) &

--- a/src/stat.f90
+++ b/src/stat.f90
@@ -225,9 +225,15 @@ contains
          a_npp, prc_r, CCN)
     if (debug) WRITE (0,*) 'statistics: micro3 ok    myid=',myid
 
-    if (level ==4) call accum_lvl4(nzp, nxp, nyp, dn0, zm, vapor, a_ricep, a_rsnowp, a_rgrp,a_nicep,prc_i,prc_s,prc_g)
+    if (level ==4) then
+       call accum_lvl4(nzp, nxp, nyp, dn0, zm, vapor, a_ricep, a_rsnowp, a_rgrp, &
+                       a_nicep,prc_i,prc_s,prc_g)
+    end if
 
-    if (level ==5) call accum_lvl4(nzp, nxp, nyp, dn0, zm, vapor, a_ricep, a_rsnowp, a_rgrp,a_nicep,prc_i,prc_s,prc_g,a_rhailp,prc_h)
+    if (level ==5) then
+       call accum_lvl4(nzp, nxp, nyp, dn0, zm, vapor, a_ricep, a_rsnowp, a_rgrp, &
+                       a_nicep,prc_i,prc_s,prc_g,a_rhailp,prc_h)
+    end if
 
     if (debug) WRITE (0,*) 'statistics: micro ok    myid=',myid
 
@@ -441,7 +447,8 @@ contains
                                    lflxd_ca(n1,n2,n3),sflxu_ca(n1,n2,n3),sflxd_ca(n1,n2,n3) ,&
                                    sflxu_toa(n2,n3),sflxd_toa(n2,n3),lflxu_toa(n2,n3),lflxd_toa(n2,n3),&
                                    sflxu_toa_ca(n2,n3),sflxd_toa_ca(n2,n3),lflxu_toa_ca(n2,n3),lflxd_toa_ca(n2,n3),&
-                                   dn0(n1),dzt(n1),pi0(n1),pi1(n1),a_pexnr(n1,n2,n3),a_theta(n1,n2,n3),CCN,cntlat,sst,time_in,vapor(n1,n2,n3)
+                                   dn0(n1),dzt(n1),pi0(n1),pi1(n1),a_pexnr(n1,n2,n3),a_theta(n1,n2,n3),CCN,cntlat, &
+                                   sst,time_in,vapor(n1,n2,n3)
    integer, optional,intent(in) :: radtyp
 
     integer :: k

--- a/src/step.f90
+++ b/src/step.f90
@@ -64,7 +64,7 @@ contains
   !
   subroutine stepper
 
-    use mpi_interface, only : myid, broadcast_dbl, double_scalar_par_max,mpi_get_time
+    use mpi_interface, only : myid, broadcast_dbl, real_scalar_par_max,mpi_get_time
     use grid, only : dt, dtlong, zt, zm, nzp, dn0, u0, v0, level, &
          write_hist
     use ncio, only : write_anal, close_anal
@@ -103,10 +103,10 @@ contains
        time = time + dt
 
        call cfl(cflmax)
-       call double_scalar_par_max(cflmax,gcflmax)
+       call real_scalar_par_max(cflmax,gcflmax)
        cflmax = gcflmax
        call peclet(pecletmax)
-       call double_scalar_par_max(pecletmax,gpecletmax)
+       call real_scalar_par_max(pecletmax,gpecletmax)
        pecletmax = gpecletmax
        dt_prev = dt
        dt = min(dtlong,dt*peak_cfl/(cflmax+epsilon(1.)))
@@ -171,7 +171,8 @@ contains
                        istp, time, dt_prev, t2-t1
               else
                 print "('   Timestep # ',i6," //     &
-                       "'   Model time(sec)=',f12.2,3x,'dt(sec)=',f8.4,'   CPU time(sec)=',f8.3'  WC Time left(sec) = ',f10.2)",     &
+                       "'   Model time(sec)=',f12.2,3x,'dt(sec)=',f8.4,'   CPU time(sec)=',f8.3'  "&
+                       "WC Time left(sec) = ',f10.2)",     &
                        istp, time, dt_prev, t2-t1, wctime-t2+t0
               end if
           end if
@@ -751,7 +752,7 @@ contains
 
     use grid, only : u0, v0, a_up, a_vp, a_wp, a_tp, a_ut, a_vt, a_wt, a_tt,&
          nfpt, spngt, spngm, nzp, nxp, nyp, th0, th00, lspongeinit
-    use mpi_interface, only : double_array_par_sum,nxpg,nypg
+    use mpi_interface, only : real_array_par_sum,nxpg,nypg
 
     integer :: i, j, k, kk
     real :: tbarg(nfpt),tbarl(nfpt),ubarg(nfpt),ubarl(nfpt),vbarg(nfpt),vbarl(nfpt)
@@ -781,9 +782,9 @@ contains
            vbarl(kk) = sum(a_vp(k,3:nxp-2,3:nyp-2))
          end do
 
-         call double_array_par_sum(tbarl,tbarg,nfpt)
-         call double_array_par_sum(ubarl,ubarg,nfpt)
-         call double_array_par_sum(vbarl,vbarg,nfpt)
+         call real_array_par_sum(tbarl,tbarg,nfpt)
+         call real_array_par_sum(ubarl,ubarg,nfpt)
+         call real_array_par_sum(vbarl,vbarg,nfpt)
 
          ngrid = (nxpg-4)*(nypg-4)
          do k = 1,nfpt

--- a/src/util.f90
+++ b/src/util.f90
@@ -142,14 +142,14 @@ contains
   !
   subroutine get_avg3(n1,n2,n3,a,avg)
 
-    use mpi_interface, only : nypg,nxpg,double_array_par_sum
+    use mpi_interface, only : nypg,nxpg,real_array_par_sum
 
     integer,intent(in) :: n1,n2,n3
     real,intent(in) :: a(n1,n2,n3)
     real,intent(out) :: avg(n1)
 
     integer      :: k,i,j
-    real(kind=8) :: lavg(n1),gavg(n1),x
+    real :: lavg(n1),gavg(n1),x
 
     x = 1./(real(nypg-4)*real(nxpg-4))
     gavg(:) = 0.
@@ -161,7 +161,7 @@ contains
        end do
     end do
     lavg = gavg
-    call double_array_par_sum(lavg,gavg,n1)
+    call real_array_par_sum(lavg,gavg,n1)
     avg(:) = real(gavg(:) * x)
 
   end subroutine get_avg3
@@ -266,7 +266,7 @@ contains
   subroutine get_var3(n1,n2,n3,a,b,avg)
 
 
-    use mpi_interface, only : nypg,nxpg,double_array_par_sum
+    use mpi_interface, only : nypg,nxpg,real_array_par_sum
 
     integer,intent(in) :: n1,n2,n3
     real,intent(in) :: a(n1,n2,n3)
@@ -274,7 +274,7 @@ contains
     real,intent(out) :: avg(n1)
 
     integer      :: k,i,j
-    real(kind=8) :: lavg(n1),gavg(n1),x
+    real :: lavg(n1),gavg(n1),x
 
     x = 1./(real(nypg-4)*real(nxpg-4))
     gavg(:) = 0.
@@ -286,7 +286,7 @@ contains
        end do
     end do
     lavg = gavg
-    call double_array_par_sum(lavg,gavg,n1)
+    call real_array_par_sum(lavg,gavg,n1)
     avg(:) = real(gavg(:) * x)
 
 
@@ -466,7 +466,7 @@ contains
      
   subroutine calclevel(varin,varout,location, threshold)
     use grid, only : nzp, nxp, nyp, zt
-    use mpi_interface, only : double_scalar_par_max, double_scalar_par_min
+    use mpi_interface, only : real_scalar_par_max, real_scalar_par_min
     real, intent(in), dimension(:,:,:) :: varin
     real, intent(in), optional :: threshold
     integer, intent(out) :: varout
@@ -497,7 +497,7 @@ contains
         end do
       end do
       rlocal = klocal
-      call double_scalar_par_max(rlocal,rglobal) 
+      call real_scalar_par_max(rlocal,rglobal) 
       varout = rglobal
     case ('base')
       klocal = nzp 
@@ -512,7 +512,7 @@ contains
         end do
       end do
       rlocal = klocal
-      call double_scalar_par_min(rlocal,rglobal) 
+      call real_scalar_par_min(rlocal,rglobal) 
       varout = rglobal
 
     end select


### PR DESCRIPTION
Add missing subroutines that specialise correctly on types (rather than
relying on implicit type-casting during call) to support newer gfortran
versions (tested with `7.5.0` and `9.3.0`)